### PR TITLE
Update dockerfile to use supported image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
-FROM node:6-onbuild
+FROM node:14-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install && npm cache clean --force
+COPY . /usr/src/app
+
+CMD [ "npm", "start" ]
 
 EXPOSE 3000


### PR DESCRIPTION
Created by hand-patching the `onbuild` commands from the previous image to match modern Docker.

Tested this by running on GCP Cloud Run, not sure if there's a better path for testing.