### PR TITLE
Add null check to eat check

### DIFF
--- a/src/server/map/player.js
+++ b/src/server/map/player.js
@@ -72,6 +72,7 @@ class Cell {
     // 1: A ate B
     // 2: B ate A
     static checkWhoAteWho(cellA, cellB) {
+        if (!cellA || !cellB) return 0;
         let response = new sat.Response();
         let colliding = sat.testCircleCircle(cellA.toCircle(), cellB.toCircle(), response);
         if (!colliding) return 0;


### PR DESCRIPTION
Whenever things got exciting, the server would crash on this line.
I believe it is a cell merge concurrency issue where the player cell to be checked is no longer there. A simple null check has allowed us to play long games without crashing.