### PR TITLE
Log incorrect password

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 ### TODOs
 | Filename | line # | TODO
 |:------|:------:|:------
-| server/server.js | 364 | Actually log incorrect passwords.
 | client/js/app.js | 96 | Break out into GameControls.
 | client/js/chat-client.js | 24 | Break out many of these GameControls into separate classes.

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -122,7 +122,7 @@ const addPlayer = (socket) => {
             socket.broadcast.emit('serverMSG', currentPlayer.name + ' just logged in as an admin.');
             currentPlayer.admin = true;
         } else {
-            console.log('[ADMIN] ' + currentPlayer.name + ' attempted to log in with incorrect password.');
+            console.log('[ADMIN] ' + currentPlayer.name + ' attempted to log in with the incorrect password: ' + password);
 
             socket.emit('serverMSG', 'Password incorrect, attempt logged.');
 


### PR DESCRIPTION
Based on TODO.md, log the incorrect password that user attempted along with existing message to the console (I don't know why the original said line 364, I assume a lot of refactoring has gone on since 2017 ;p)

<img width="1195" alt="Screenshot 2025-03-11 at 11 32 22 PM" src="https://github.com/user-attachments/assets/2eae6a31-422b-4b75-bb42-e86ba6d0d795" />

<img width="626" alt="Screenshot 2025-03-11 at 11 32 29 PM" src="https://github.com/user-attachments/assets/bd45bd31-6a04-4450-9769-6bcbae09d876" />

